### PR TITLE
Add IRAC programme

### DIFF
--- a/pages/irac-2022.md
+++ b/pages/irac-2022.md
@@ -107,7 +107,7 @@ time        | presentation
 11:15-11:30	| **Hans van Gasteren** - Validation of local bird radars used in military aviation
 11:30-11:45	| **Arndt Wellbrock** - Flying across the sea – possibilities and limitations of weather radar data for the understanding of bird migration over the Baltic Sea **remote**{: .badge .bg-secondary }
 11:45-12:00	| **Maja Bradarić** - On the radar: offshore wind turbine curtailment informed by nocturnal bird migration predictions
-12:00-13:30 | Lunch break
+12:00-13:30 | Lunch break
 **Session 3**{: .text-primary } | **Applied radar aeroecology - the knowledge base for conservation and management**{: .text-primary }
 13:30-14:00 | **Gao Bayo** - Migration basics insects **keynote**{: .badge .bg-secondary } **remote**{: .badge .bg-secondary }
 14:00-14:15	| **Theodore Zenzal** - A Bioenergetic Model to Facilitate Migratory Landbird Conservation along the Northern Gulf of Mexico Coast **remote**{: .badge .bg-secondary }
@@ -120,6 +120,24 @@ time        | presentation
 16:00-16:30	| **Silke Bauer & Judy Shamoun-Baranes** - Concluding talk 
 17:00+      | Drinks & poster session
 
+## Posters
+
+\# | poster
+-- | ------
+1  | **Tsafra Evra** - Aloft and On the Ground: Do Bird Radar data and Constant Effort Bird Ringing Data of Migrants in Eilat, Israel, correlate?
+2  | **Itai Bloch** - Combining radio-telemetry and radar measurements to reveal how insect abundance affects the movements of an aerial insectivore
+3  | **Paolo Becciu** - Between sea and desert: soaring migrants beneficially modulate their flight in relation to sea-breeze
+4  | **Joseph Wayman** - Assessing the impact of fireworks on urban birds using L-Band staring radar
+5  | **Nadja Weisshaupt** - The impact of hydrometeors on bird migration as observed by various remote sensing systems
+6  | **Nadja Weisshaupt** - Dealiasing of radial velocities based on interleaved dual-PRF measurements and bin-based polarimetric echo classification
+7  | **Tom Carrard** - Bird Migration Forecast : Developing Radar-Based Forecasts of Bird Migration over Switzerland
+8  | **Yuval Werber** - RADAR in a multisensory setup: a case study to assess the impact of an aerial deterrent
+9  | **Jacco Leemans** - Distinguishing birds from waves based on radar track characteristics
+10 | **Birgen Haest** - Climatic drivers of Bracken Cave (USA) bat migration phenology and demography
+11 | **Jonne Kleyheeg-Hartman** - Developing automatic radar-controlled wind turbine shutdown to reduce collision mortality of local breeding birds.
+12 | **Peter Desmet** - CROW: Visualize bird migration in your browser
+13 | **Brian Lee** - Quantifying bat foraging effects on California agriculture using NOAA NEXRAD Doppler Radar and machine learning.
+14 | **Fanqi Gao** - Migratory behavior of the fall armyworm in Israel and its outbreak potential in Europe
 
 ## Venue, travel and accommodation
 

--- a/pages/irac-2022.md
+++ b/pages/irac-2022.md
@@ -20,8 +20,8 @@ We cordially invite you to the **3rd International Radar Aeroecology Conference 
 We invite proposals for oral and poster contributions, fitting one or more of the conference themes and presented as part of thematic sessions:
 1. Spatio-temporal movement patterns of birds, bats, and insects and their environmental influences
 2. Methodological advancements - classification and identification algorithms, radar technology, data infrastructure
-3. Applied radar aeroecology - the knowledge base for conservation and management
-4. From radar aeroecology to biodiversity
+3. From radar aeroecology to biodiversity
+4. Applied radar aeroecology - the knowledge base for conservation and management
 
 ## Keynote speakers
 
@@ -102,15 +102,15 @@ time        | presentation
 10:15-10:30 | **Xu Shi** - Prospects for monitoring bird migration along the East Asian-Australasian Flyway using weather radar **speed talk**{: .badge .bg-secondary } **remote**{: .badge .bg-secondary }
 &nbsp;      | **Lili Jia** - Using radar to mitigate birdstrike risk in coastal airport on Bohai Bay **speed talk**{: .badge .bg-secondary } **remote**{: .badge .bg-secondary }		
 10:30-11:00 | Coffee break
-**Session 4**{: .text-primary } | **From radar aeroecology to biodiversity**{: .text-primary }
+**Session 3**{: .text-primary } | **From radar aeroecology to biodiversity**{: .text-primary }
 11:00-11:15 | **Andrew Farnsworth** - From data to action: BirdCast perspectives on transforming bird migration science to conservation planning
 11:15-11:30	| **Hans van Gasteren** - Validation of local bird radars used in military aviation
 11:30-11:45	| **Arndt Wellbrock** - Flying across the sea – possibilities and limitations of weather radar data for the understanding of bird migration over the Baltic Sea **remote**{: .badge .bg-secondary }
 11:45-12:00	| **Maja Bradarić** - On the radar: offshore wind turbine curtailment informed by nocturnal bird migration predictions
 12:00-13:30 | Lunch break
-**Session 3**{: .text-primary } | **Applied radar aeroecology - the knowledge base for conservation and management**{: .text-primary }
 13:30-14:00 | **Gao Bayo** - Migration basics insects **keynote**{: .badge .bg-secondary } **remote**{: .badge .bg-secondary }
 14:00-14:15	| **Theodore Zenzal** - A Bioenergetic Model to Facilitate Migratory Landbird Conservation along the Northern Gulf of Mexico Coast **remote**{: .badge .bg-secondary }
+**Session 4**{: .text-primary } | **Applied radar aeroecology - the knowledge base for conservation and management**{: .text-primary }
 14:15-14:30	| **Elske Tielens** - Spatial patterns in diurnal aerial insect biomass and landscape level drivers across the continental United States
 14:30-14:45	| **Adriaan Dokter** - Macro-demography of North America’s migratory birds
 14:45-15:15 | Coffee break

--- a/pages/irac-2022.md
+++ b/pages/irac-2022.md
@@ -47,8 +47,79 @@ We have invited renowned speakers who will give an introductory overview for eac
 ![picture](/assets/images/irac-2022-boya-goa.jpg){: style="height: 100px; width: 100px; border-radius: 100px; border: 3px solid #e9ecef;" .me-3 .float-start}
 **Boya Gao** - Boya is a post-doctor at plant protection college, [Nanjing Agricultural University](http://english.njau.edu.cn/mainm.htm) who researches insect migration and radar entomology.
 
+## Programme
 
-<!-- ## Programme -->
+<style>
+  .table th:first-of-type {
+    width: 20%;
+  }
+</style>
+
+An optional pre-conference **bird watching excursion** to the Flüela Pass (with chance to see snowfinches) is organized by Fränzi Korner-Nievergelt. Email <irac2022@vogelwarte.ch> if you want to join.
+
+### Saturday - June 25
+
+time        | presentation
+----------- | ------------
+ 8:00-9:00  | Registration
+ 9:15-9:30  | Welcome
+**Session 1**{: .text-primary } | **Spatio-temporal movement patterns of birds, bats, and insects and their environmental influences**{: .text-primary }
+ 9:30-10:00 | **Liechti Felix** - Migration basics birds **keynote**{: .badge .bg-secondary }
+10:00-10:15 | **Nir Sapir** - Two radars in the desert - Scrutinizing bird migration dynamics over different timescales using retrospective comparison and operational prediction
+10:15-10:30 | **Birgen Haest** - Spatiotemporal movements of insects across Europe, quantified using a vertical-looking radar network
+10:30-11:00 | Coffee break
+11:00-11:15 | **Yuval Werber** - Finding bats in RADAR data: a novel approach based on Ecology, movement and machine learning
+11:15-11:30 | **Fiona Lippert** - Integrating deep learning with mechanistic modeling for spatio-temporal migration forecasts based on weather radar networks
+11:30-11:45	| **Nadja Weisshaupt** - Bin-based polarimetric echo classification for spatially flexible aeroecological purposes in combination with citizen science
+11:45-12:00 | **Bart Kranstauber** - Incorporating seasonal differences in phenology is essential for accurate bird migration forecasts
+12:00-13:30 | Lunch break
+13:30-14:00 | **Sheldon Dan** - Methodological advancements **keynote**{: .badge .bg-secondary } **remote**{: .badge .bg-secondary }
+14:00-14:15 | **Valery Melnikov** - Impacts of the differential phase upon transmission on radar variables from birds
+14:15-14:30 | **Inbal Schekler** - Automatic detection of bird flocks by weather radars
+14:30-14:45 | **Gustavo Perez** - Using Spatio-Temporal Information in Weather Radar Data to Detect Communal Bird Roosts
+14:45-15:15 | Coffee break
+15:15-15:30 | **Yuting Deng** - Quantifying phenological trends in aerial insectivore roosting behaviors in the Great Lakes region using weather surveillance radar
+15:30-15:45 | **Fengyi Guo** - Autumn stopover hotspots and multi-scale habitat associations of migratory landbirds in the eastern U.S. **remote**{: .badge .bg-secondary }
+15:45-16:00	| **Benjamin Van Doren** - Linking acoustic monitoring and radar to capture the timing and intensity of bird migration **remote**{: .badge .bg-secondary }
+16:00-16:30	| Coffee break
+16:30-17:15	| **Jennifer Krauel** - Patterns in High-altitude Bat Movement over Texas Revealed by Radar **speed talk**{: .badge .bg-secondary } **remote**{: .badge .bg-secondary }
+&nbsp;      | **Virginia Halterman** - Patterns of flight altitudes for arriving spring migrants in the Gulf of Mexico region **speed talk**{: .badge .bg-secondary } **remote**{: .badge .bg-secondary }
+&nbsp;      | **Simon Hirschhofer** - High concentrations of migratory birds in Swiss-alpine valleys more frequent in pre- than postbreeding migration **speed talk**{: .badge .bg-secondary }
+&nbsp;      | **Thibault Désert** - SEMAFOR project: remote sensing of avifauna using the French meteorological radar network **speed talk**{: .badge .bg-secondary }
+&nbsp;      | **Jens van Erp** - Identifying fine-scale flight behaviour in 2D bird radar tracks: marine thermal soaring on the North Sea **speed talk**{: .badge .bg-secondary }
+&nbsp;      | **Abel Gyimesi** - Avian avoidance of offshore wind turbines measured by radar **speed talk**{: .badge .bg-secondary }
+17:15-20:00 | Drinks & poster session
+
+### Saturday - June 26
+
+time        | presentation
+----------- | ------------
+**Session 2**{: .text-primary } | **Methodological advancements - classification and identification algorithms, radar technology, data infrastructure**{: .text-primary }
+ 9:00-9:30  | **Buler Jeff** - Applied radar aeroecology
+ 9:30-9:45	| **Bart Hoekstra** - Fireworks disturbance across bird communities
+09:45-10:00 | **William Kunin** - Tracking desert locust swarms using dual-polarisation weather radar
+10:00-10:15 | **Zhenhua Hao** - Different migratory strategies in locusts and moths revealed by radar **remote**{: .badge .bg-secondary }
+10:15-10:30 | **Xu Shi** - Prospects for monitoring bird migration along the East Asian-Australasian Flyway using weather radar **speed talk**{: .badge .bg-secondary } **remote**{: .badge .bg-secondary }
+&nbsp;      | **Lili Jia** - Using radar to mitigate birdstrike risk in coastal airport on Bohai Bay **speed talk**{: .badge .bg-secondary } **remote**{: .badge .bg-secondary }		
+10:30-11:00 | Coffee break
+**Session 4**{: .text-primary } | **From radar aeroecology to biodiversity**{: .text-primary }
+11:00-11:15 | **Andrew Farnsworth** - From data to action: BirdCast perspectives on transforming bird migration science to conservation planning
+11:15-11:30	| **Hans van Gasteren** - Validation of local bird radars used in military aviation
+11:30-11:45	| **Arndt Wellbrock** - Flying across the sea – possibilities and limitations of weather radar data for the understanding of bird migration over the Baltic Sea **remote**{: .badge .bg-secondary }
+11:45-12:00	| **Maja Bradarić** - On the radar: offshore wind turbine curtailment informed by nocturnal bird migration predictions
+12:00-13:30 | Lunch break
+**Session 3**{: .text-primary } | **Applied radar aeroecology - the knowledge base for conservation and management**{: .text-primary }
+13:30-14:00 | **Gao Bayo** - Migration basics insects **keynote**{: .badge .bg-secondary } **remote**{: .badge .bg-secondary }
+14:00-14:15	| **Theodore Zenzal** - A Bioenergetic Model to Facilitate Migratory Landbird Conservation along the Northern Gulf of Mexico Coast **remote**{: .badge .bg-secondary }
+14:15-14:30	| **Elske Tielens** - Spatial patterns in diurnal aerial insect biomass and landscape level drivers across the continental United States
+14:30-14:45	| **Adriaan Dokter** - Macro-demography of North America’s migratory birds
+14:45-15:15 | Coffee break
+15:15-15:30	| **Raphaël Nussbaumer** - Aerial and terrestrial biomass flows of migratory birds across the US
+15:30:15:45	| **Christopher Hassall** - Weather surveillance radar for biodiversity monitoring in the UK
+15:45-16:00	| **Jason Chapman** - Long-term trends of insect migration patterns above the USA
+16:00-16:30	| **Silke Bauer & Judy Shamoun-Baranes** - Concluding talk 
+17:00+      | Drinks & poster session
+
 
 ## Venue, travel and accommodation
 

--- a/pages/irac-2022.md
+++ b/pages/irac-2022.md
@@ -64,7 +64,7 @@ time        | presentation
  8:00-9:00  | Registration
  9:15-9:30  | Welcome
 **Session 1**{: .text-primary } | **Spatio-temporal movement patterns of birds, bats, and insects and their environmental influences**{: .text-primary }
- 9:30-10:00 | **Liechti Felix** - Migration basics birds **keynote**{: .badge .bg-secondary }
+ 9:30-10:00 | **Felix Liechti** - Migration basics for birds **keynote**{: .badge .bg-danger }
 10:00-10:15 | **Nir Sapir** - Two radars in the desert - Scrutinizing bird migration dynamics over different timescales using retrospective comparison and operational prediction
 10:15-10:30 | **Birgen Haest** - Spatiotemporal movements of insects across Europe, quantified using a vertical-looking radar network
 10:30-11:00 | Coffee break
@@ -73,17 +73,17 @@ time        | presentation
 11:30-11:45	| **Nadja Weisshaupt** - Bin-based polarimetric echo classification for spatially flexible aeroecological purposes in combination with citizen science
 11:45-12:00 | **Bart Kranstauber** - Incorporating seasonal differences in phenology is essential for accurate bird migration forecasts
 12:00-13:30 | Lunch break
-13:30-14:00 | **Sheldon Dan** - Methodological advancements **keynote**{: .badge .bg-secondary } **remote**{: .badge .bg-secondary }
+13:30-14:00 | **Dan Sheldon** - Methodological advancements **keynote**{: .badge .bg-danger } **remote**{: .badge .bg-light .text-dark }
 14:00-14:15 | **Valery Melnikov** - Impacts of the differential phase upon transmission on radar variables from birds
 14:15-14:30 | **Inbal Schekler** - Automatic detection of bird flocks by weather radars
 14:30-14:45 | **Gustavo Perez** - Using Spatio-Temporal Information in Weather Radar Data to Detect Communal Bird Roosts
 14:45-15:15 | Coffee break
 15:15-15:30 | **Yuting Deng** - Quantifying phenological trends in aerial insectivore roosting behaviors in the Great Lakes region using weather surveillance radar
-15:30-15:45 | **Fengyi Guo** - Autumn stopover hotspots and multi-scale habitat associations of migratory landbirds in the eastern U.S. **remote**{: .badge .bg-secondary }
-15:45-16:00	| **Benjamin Van Doren** - Linking acoustic monitoring and radar to capture the timing and intensity of bird migration **remote**{: .badge .bg-secondary }
+15:30-15:45 | **Fengyi Guo** - Autumn stopover hotspots and multi-scale habitat associations of migratory landbirds in the eastern U.S. **remote**{: .badge .bg-light .text-dark }
+15:45-16:00	| **Benjamin Van Doren** - Linking acoustic monitoring and radar to capture the timing and intensity of bird migration **remote**{: .badge .bg-light .text-dark }
 16:00-16:30	| Coffee break
-16:30-17:15	| **Jennifer Krauel** - Patterns in High-altitude Bat Movement over Texas Revealed by Radar **speed talk**{: .badge .bg-secondary } **remote**{: .badge .bg-secondary }
-&nbsp;      | **Virginia Halterman** - Patterns of flight altitudes for arriving spring migrants in the Gulf of Mexico region **speed talk**{: .badge .bg-secondary } **remote**{: .badge .bg-secondary }
+16:30-17:15	| **Jennifer Krauel** - Patterns in High-altitude Bat Movement over Texas Revealed by Radar **speed talk**{: .badge .bg-secondary } **remote**{: .badge .bg-light .text-dark }
+&nbsp;      | **Virginia Halterman** - Patterns of flight altitudes for arriving spring migrants in the Gulf of Mexico region **speed talk**{: .badge .bg-secondary } **remote**{: .badge .bg-light .text-dark }
 &nbsp;      | **Simon Hirschhofer** - High concentrations of migratory birds in Swiss-alpine valleys more frequent in pre- than postbreeding migration **speed talk**{: .badge .bg-secondary }
 &nbsp;      | **Thibault Désert** - SEMAFOR project: remote sensing of avifauna using the French meteorological radar network **speed talk**{: .badge .bg-secondary }
 &nbsp;      | **Jens van Erp** - Identifying fine-scale flight behaviour in 2D bird radar tracks: marine thermal soaring on the North Sea **speed talk**{: .badge .bg-secondary }
@@ -95,29 +95,29 @@ time        | presentation
 time        | presentation
 ----------- | ------------
 **Session 2**{: .text-primary } | **Methodological advancements - classification and identification algorithms, radar technology, data infrastructure**{: .text-primary }
- 9:00-9:30  | **Buler Jeff** - Applied radar aeroecology
+ 9:00-9:30  | **Jeff Buler** - Applied radar aeroecology
  9:30-9:45	| **Bart Hoekstra** - Fireworks disturbance across bird communities
 09:45-10:00 | **William Kunin** - Tracking desert locust swarms using dual-polarisation weather radar
-10:00-10:15 | **Zhenhua Hao** - Different migratory strategies in locusts and moths revealed by radar **remote**{: .badge .bg-secondary }
-10:15-10:30 | **Xu Shi** - Prospects for monitoring bird migration along the East Asian-Australasian Flyway using weather radar **speed talk**{: .badge .bg-secondary } **remote**{: .badge .bg-secondary }
-&nbsp;      | **Lili Jia** - Using radar to mitigate birdstrike risk in coastal airport on Bohai Bay **speed talk**{: .badge .bg-secondary } **remote**{: .badge .bg-secondary }		
+10:00-10:15 | **Zhenhua Hao** - Different migratory strategies in locusts and moths revealed by radar **remote**{: .badge .bg-light .text-dark }
+10:15-10:30 | **Xu Shi** - Prospects for monitoring bird migration along the East Asian-Australasian Flyway using weather radar **speed talk**{: .badge .bg-secondary } **remote**{: .badge .bg-light .text-dark }
+&nbsp;      | **Lili Jia** - Using radar to mitigate birdstrike risk in coastal airport on Bohai Bay **speed talk**{: .badge .bg-secondary } **remote**{: .badge .bg-light .text-dark }		
 10:30-11:00 | Coffee break
 **Session 3**{: .text-primary } | **From radar aeroecology to biodiversity**{: .text-primary }
 11:00-11:15 | **Andrew Farnsworth** - From data to action: BirdCast perspectives on transforming bird migration science to conservation planning
 11:15-11:30	| **Hans van Gasteren** - Validation of local bird radars used in military aviation
-11:30-11:45	| **Arndt Wellbrock** - Flying across the sea – possibilities and limitations of weather radar data for the understanding of bird migration over the Baltic Sea **remote**{: .badge .bg-secondary }
+11:30-11:45	| **Arndt Wellbrock** - Flying across the sea – possibilities and limitations of weather radar data for the understanding of bird migration over the Baltic Sea **remote**{: .badge .bg-light .text-dark }
 11:45-12:00	| **Maja Bradarić** - On the radar: offshore wind turbine curtailment informed by nocturnal bird migration predictions
 12:00-13:30 | Lunch break
-13:30-14:00 | **Gao Bayo** - Migration basics insects **keynote**{: .badge .bg-secondary } **remote**{: .badge .bg-secondary }
-14:00-14:15	| **Theodore Zenzal** - A Bioenergetic Model to Facilitate Migratory Landbird Conservation along the Northern Gulf of Mexico Coast **remote**{: .badge .bg-secondary }
 **Session 4**{: .text-primary } | **Applied radar aeroecology - the knowledge base for conservation and management**{: .text-primary }
+13:30-14:00 | **Bayo Gao** - Migration basics for insects **keynote**{: .badge .bg-danger } **remote**{: .badge .bg-light .text-dark }
+14:00-14:15	| **Theodore Zenzal** - A Bioenergetic Model to Facilitate Migratory Landbird Conservation along the Northern Gulf of Mexico Coast **remote**{: .badge .bg-light .text-dark }
 14:15-14:30	| **Elske Tielens** - Spatial patterns in diurnal aerial insect biomass and landscape level drivers across the continental United States
 14:30-14:45	| **Adriaan Dokter** - Macro-demography of North America’s migratory birds
 14:45-15:15 | Coffee break
 15:15-15:30	| **Raphaël Nussbaumer** - Aerial and terrestrial biomass flows of migratory birds across the US
 15:30:15:45	| **Christopher Hassall** - Weather surveillance radar for biodiversity monitoring in the UK
 15:45-16:00	| **Jason Chapman** - Long-term trends of insect migration patterns above the USA
-16:00-16:30	| **Silke Bauer & Judy Shamoun-Baranes** - Concluding talk 
+16:00-16:30	| **Silke Bauer & Judy Shamoun-Baranes** - Concluding talk **keynote**{: .badge .bg-danger }
 17:00+      | Drinks & poster session
 
 ## Posters

--- a/pages/irac-2022.md
+++ b/pages/irac-2022.md
@@ -11,11 +11,9 @@ We cordially invite you to the **3rd International Radar Aeroecology Conference 
 {: .col-md-8 .mx-auto}
 ![irac-2022](/assets/images/irac-2022-logo.png)
 
-## Important dates
+## Registration
 
-**Abstract submission deadline: extended to 1 March 2022**, now closed.
-
-Registration: opens 20 April 2022 and closes 31 May 2022.
+[Register now](https://www.eventbrite.com/e/3rd-international-radar-aeroecology-conference-irac-2022-tickets-216254331527){: .btn .btn-primary }
 
 ## Thematic sessions
 
@@ -49,11 +47,6 @@ We have invited renowned speakers who will give an introductory overview for eac
 ![picture](/assets/images/irac-2022-boya-goa.jpg){: style="height: 100px; width: 100px; border-radius: 100px; border: 3px solid #e9ecef;" .me-3 .float-start}
 **Boya Gao** - Boya is a post-doctor at plant protection college, [Nanjing Agricultural University](http://english.njau.edu.cn/mainm.htm) who researches insect migration and radar entomology.
 
-## Abstract submission
-
-[Abstract submission](https://forms.gle/8B9VVcf5Mq2tERhZ8){: .btn .btn-primary }
-
-<!-- ## Registration -->
 
 <!-- ## Programme -->
 

--- a/pages/irac-2022.md
+++ b/pages/irac-2022.md
@@ -136,8 +136,7 @@ time        | presentation
 10 | **Birgen Haest** - Climatic drivers of Bracken Cave (USA) bat migration phenology and demography
 11 | **Jonne Kleyheeg-Hartman** - Developing automatic radar-controlled wind turbine shutdown to reduce collision mortality of local breeding birds.
 12 | **Peter Desmet** - CROW: Visualize bird migration in your browser
-13 | **Brian Lee** - Quantifying bat foraging effects on California agriculture using NOAA NEXRAD Doppler Radar and machine learning.
-14 | **Fanqi Gao** - Migratory behavior of the fall armyworm in Israel and its outbreak potential in Europe
+13 | **Fanqi Gao** - Migratory behavior of the fall armyworm in Israel and its outbreak potential in Europe
 
 ## Venue, travel and accommodation
 


### PR DESCRIPTION
I translated the programme spreadsheet to a table that will be included on https://globam.science/irac-2022/ under a section `Programme`. A screenshot is included below

- I used a simple table approach with two columns: `time` + `presentation`. The second column contains `Author - Title` or a description (e.g. `Coffee break`)
- I left out any information that I don't consider relevant (like talk numbers)
- I use badges to indicate `keynote`, `speed talk` and `remote`
- Sessions are indicated in green, they take the title from the topic with that number
- I will likely link the title talk to another page where all the abstracts are listed.

## Todo by @bart1 @BirgenH @silkebauer ...

- [x] If the session numbers refer to the [topics numbers](https://globam.science/irac-2022/#thematic-sessions), we should switch 3 and 4, because currently 4 is happening before 3. Let me know if you agree.
- [ ] Check the `keynote`, `remote`, `speed talk` badges are correctly assigned
- [x] Provide better titles for the introductory talks?
- [ ] Let me know if I can copy/paste abstracts from the form spreadsheet


![3rd-International-Radar-Aeroecology-Conference-GloBAM](https://user-images.githubusercontent.com/600993/165984541-6c1396f9-ac1f-4745-b72d-433499044202.png)

